### PR TITLE
fix(login): replace broken alert with custom notification after password set

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -7,7 +7,7 @@ body {
   height: 450px;
   width: 350px;
   margin: 0px;
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   background-color: #f9f9f9;
   color: #0f0f0f;
 }
@@ -48,6 +48,50 @@ input[type="text"]:focus {
   outline: none;
 }
 
+.custom-notification {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+.notification-content {
+  background-color: #fff;
+  color: #0f0f0f;
+  padding: 20px 25px;
+  border-radius: 4px;
+  text-align: center;
+  width: 280px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.notification-content h3 {
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+.notification-content p {
+  margin: 0 0 15px 0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+#notification-close {
+  padding: 8px 20px;
+  margin: 0;
+  width: auto;
+  min-width: 80px;
+  display: inline-block;
+}
+
 button {
   padding: 8px 16px;
   border: none;
@@ -82,7 +126,7 @@ button {
   display: block;
   background: none;
   border: none;
-  color: #065FD4;
+  color: #065fd4;
   text-decoration: none;
   cursor: pointer;
   font-size: 0.8rem;
@@ -98,14 +142,14 @@ button {
 
 .text-danger {
   text-align: center;
-  color: #CC0000;
+  color: #cc0000;
   font-size: 0.85rem;
   margin-top: 6px;
 }
 
 .current-word {
   font-weight: 500;
-  font-size: 1.0rem;
+  font-size: 1rem;
   margin-bottom: 10px;
 }
 
@@ -166,6 +210,12 @@ html[dark_mode="true"] .forgot-btn {
 html[dark_mode="true"] .forgot-btn:hover {
   color: #a0c0ff;
   text-decoration: underline;
+}
+
+html[dark_mode="true"] .notification-content {
+  background-color: #2a2a2a;
+  color: #e0e0e0;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 
 /* --- Disable all transitions initially --- */

--- a/js/login.js
+++ b/js/login.js
@@ -17,6 +17,11 @@ const confirmPasswordInput = document.getElementById("confirm-password");
 const saveButton = document.getElementById("save-password");
 const setupError = document.getElementById("setup-error");
 
+// --- Custom notification elements ---
+const customNotification = document.getElementById("custom-notification");
+const notificationMessage = document.getElementById("notification-message");
+const notificationCloseButton = document.getElementById("notification-close");
+
 // --- Reset elements ---
 const currentWordEl = document.getElementById("current-word");
 const resetInput = document.getElementById("reset-input");
@@ -24,14 +29,24 @@ const resetNextBtn = document.getElementById("reset-next");
 
 // --- Reset words ---
 const resetWords = [
-  "orange", "castle", "mirror", "planet", "forest",
-  "window", "guitar", "breeze", "pillow", "dragon"
+  "orange",
+  "castle",
+  "mirror",
+  "planet",
+  "forest",
+  "window",
+  "guitar",
+  "breeze",
+  "pillow",
+  "dragon",
 ];
 let currentResetIndex = 0;
 
 // --- Helper to show/hide containers ---
 function showContainer(container) {
-  [loginContainer, setupContainer, resetContainer].forEach(c => c.classList.add("hidden"));
+  [loginContainer, setupContainer, resetContainer].forEach((c) =>
+    c.classList.add("hidden")
+  );
   container.classList.remove("hidden");
 }
 
@@ -92,14 +107,14 @@ saveButton.addEventListener("click", async () => {
   }
 
   if (!isStrongPassword(newPass)) {
-    setupError.textContent = "Password must be at least 8 characters and include uppercase, lowercase, number, and special character.";
+    setupError.textContent =
+      "Password must be at least 8 characters and include uppercase, lowercase, number, and special character.";
     setupError.classList.remove("hidden");
     return;
   }
 
   await chrome.storage.local.set({ extensionPassword: newPass });
-  alert("Password set successfully! Please log in.");
-  showContainer(loginContainer);
+  showNotification("Password set successfully! Please log in.");
   setupError.classList.add("hidden");
 });
 
@@ -144,18 +159,50 @@ resetNextBtn.addEventListener("click", async () => {
 
     if (currentResetIndex >= resetWords.length) {
       await chrome.storage.local.remove("extensionPassword");
-      alert("Password reset successful! Please set a new password.");
-      showContainer(setupContainer);
+      showNotification(
+        "Password reset successful! Please set a new password.",
+        setupContainer
+      );
     } else {
       showCurrentWord();
     }
   } else {
-    alert("Incorrect word! Start over.");
+    showNotification("Incorrect word! Start over.");
     currentResetIndex = 0;
     resetInput.value = "";
     showCurrentWord();
   }
 });
+
+// --- Custom notification function ---
+function showNotification(message, targetContainer = loginContainer) {
+  notificationMessage.textContent = message;
+
+  // Show the notification
+  customNotification.style.opacity = "0";
+  customNotification.classList.remove("hidden");
+
+  void customNotification.offsetWidth;
+  customNotification.style.opacity = "1";
+
+  // Focus the OK button
+  setTimeout(() => {
+    notificationCloseButton.focus();
+  }, 100);
+
+  // Setup event listener for the OK button
+  notificationCloseButton.addEventListener("click", function closeHandler() {
+    // Fade out effect
+    customNotification.style.opacity = "0";
+
+    // Wait for transition to complete before hiding
+    setTimeout(() => {
+      customNotification.classList.add("hidden");
+      showContainer(targetContainer);
+      notificationCloseButton.removeEventListener("click", closeHandler);
+    }, 300);
+  });
+}
 
 // --- Initialize on DOM load ---
 window.addEventListener("DOMContentLoaded", () => {

--- a/login.html
+++ b/login.html
@@ -1,41 +1,58 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Unlock Extension</title>
-  <link rel="stylesheet" href="css/login.css" />
-</head>
-<body>
-  <div class="card-container">
-    <!-- Setup password form -->
-    <div id="setup-container" class="hidden">
-      <h3>Set Password</h3>
-      <input type="password" id="new-password" placeholder="Enter password" />
-      <input type="password" id="confirm-password" placeholder="Confirm password" />
-      <button id="save-password" class="btn-success">Save Password</button>
-      <p id="setup-error" class="text-danger hidden">Passwords do not match!</p>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Unlock Extension</title>
+    <link rel="stylesheet" href="css/login.css" />
+  </head>
+  <body>
+    <!-- Custom notification element -->
+    <div id="custom-notification" class="custom-notification hidden">
+      <div class="notification-content">
+        <h3>BetterTube</h3>
+        <p id="notification-message"></p>
+        <button id="notification-close" class="btn-primary">OK</button>
+      </div>
     </div>
 
-    <!-- Login form -->
-    <div id="login-container" class="hidden">
-      <h3>Enter Password</h3>
-      <input type="password" id="password-input" placeholder="Password" />
-      <button id="submit-password" class="btn-primary">Unlock</button>
-      <button id="forgot-password" class="forgot-btn">Forgot Password?</button>
-      <p id="error-message" class="text-danger hidden">Incorrect password!</p>
+    <div class="card-container">
+      <!-- Setup password form -->
+      <div id="setup-container" class="hidden">
+        <h3>Set Password</h3>
+        <input type="password" id="new-password" placeholder="Enter password" />
+        <input
+          type="password"
+          id="confirm-password"
+          placeholder="Confirm password"
+        />
+        <button id="save-password" class="btn-success">Save Password</button>
+        <p id="setup-error" class="text-danger hidden">
+          Passwords do not match!
+        </p>
+      </div>
+
+      <!-- Login form -->
+      <div id="login-container" class="hidden">
+        <h3>Enter Password</h3>
+        <input type="password" id="password-input" placeholder="Password" />
+        <button id="submit-password" class="btn-primary">Unlock</button>
+        <button id="forgot-password" class="forgot-btn">
+          Forgot Password?
+        </button>
+        <p id="error-message" class="text-danger hidden">Incorrect password!</p>
+      </div>
+
+      <!-- Password reset form -->
+      <div id="reset-container" class="hidden">
+        <h3>Reset Password</h3>
+        <p>Type the following word:</p>
+        <div id="current-word" class="current-word"></div>
+        <input type="text" id="reset-input" placeholder="Type the word here" />
+        <button id="reset-next" class="btn-warning">Next</button>
+      </div>
     </div>
 
-    <!-- Password reset form -->
-    <div id="reset-container" class="hidden">
-      <h3>Reset Password</h3>
-      <p>Type the following word:</p>
-      <div id="current-word" class="current-word"></div>
-      <input type="text" id="reset-input" placeholder="Type the word here" />
-      <button id="reset-next" class="btn-warning">Next</button>
-    </div>
-  </div>
-
-  <script src="js/login.js"></script>
-</body>
+    <script src="js/login.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
### Summary

This PR fixes a bug where the alert "Password set successfully, please login" did not close properly after setting a password during the login process.

The alert has been removed and replaced with a custom in-extension notification for an improved user experience and a consistent UI.

### Changes Made

- Removed the default `alert()` from the login flow
- Added a custom notification element to display a success message after the password is set
- Ensured the notification can be dismissed manually by the user

### Screenshots
<img width="1630" height="657" alt="Screenshot from 2025-10-10 21-04-58" src="https://github.com/user-attachments/assets/9e4b0406-8ea3-4f81-ac4e-7e096291d8a5" />
<img width="1630" height="657" alt="Screenshot from 2025-10-10 21-05-05" src="https://github.com/user-attachments/assets/60118542-ea2d-4086-a544-2249a19337c2" />




